### PR TITLE
Unfree, 23.11 and lots more

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1694205128,
-        "narHash": "sha256-JfSO61vzeZEtk+2vQUvBgDeiywGSkHBq7JmKpUCFzZ0=",
+        "lastModified": 1704310048,
+        "narHash": "sha256-eAxFGlZllel+viidYQsocPckbLp7xQD9jg3+vW5wx9I=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "2ef7a61cd972e56b31d007a47ae7147856e75888",
+        "rev": "4c479a9ab1b44668c5c0001f6cc447edf31603ef",
         "type": "gitlab"
       },
       "original": {
@@ -43,16 +43,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1693208669,
-        "narHash": "sha256-hHFaaUsZ860wvppPeiu7nJn/nXZjJfnqAQEu9SPFE9I=",
+        "lastModified": 1704099619,
+        "narHash": "sha256-QRVMkdxLmv+aKGjcgeEg31xtJEIsYq4i1Kbyw5EPS6g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5bac4a1c06cd77cf8fc35a658ccb035a6c50cd2c",
+        "rev": "7e398b3d76bc1503171b1364c9d4a07ac06f3851",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -75,16 +75,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1694048570,
-        "narHash": "sha256-PEQptwFCVaJ+jLFJgrZll2shQ9VI/7xVhrCYkJo8iIw=",
+        "lastModified": 1703992652,
+        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4f77ea639305f1de0a14d9d41eef83313360638c",
+        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1704310048,
-        "narHash": "sha256-eAxFGlZllel+viidYQsocPckbLp7xQD9jg3+vW5wx9I=",
+        "lastModified": 1706306805,
+        "narHash": "sha256-BWJdcDmpqZuxCStx4RUl5SD6uELy8hRa5YzwFTdWrts=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "4c479a9ab1b44668c5c0001f6cc447edf31603ef",
+        "rev": "24985136f4a5f98254e88c26d428114d206c2565",
         "type": "gitlab"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704099619,
-        "narHash": "sha256-QRVMkdxLmv+aKGjcgeEg31xtJEIsYq4i1Kbyw5EPS6g=",
+        "lastModified": 1705659542,
+        "narHash": "sha256-WA3xVfAk1AYmFdwghT7mt/erYpsU6JPu9mdTEP/e9HQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7e398b3d76bc1503171b1364c9d4a07ac06f3851",
+        "rev": "10cd9c53115061aa6a0a90aad0b0dde6a999cdb9",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703992652,
-        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
+        "lastModified": 1706098335,
+        "narHash": "sha256-r3dWjT8P9/Ah5m5ul4WqIWD8muj5F+/gbCdjiNVBKmU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
+        "rev": "a77ab169a83a4175169d78684ddd2e54486ac651",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1708805268,
-        "narHash": "sha256-TyB6HacqcoIoK8tf5mwk/K9bkexCxjJsVXBp4+cbATI=",
+        "lastModified": 1709611437,
+        "narHash": "sha256-hp3DnOInK1cVgxMQgr9F0opToc6U3iwZF6rLURv+Guw=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "211c45ca8c36d7aebcff3e4b548142093fc85857",
+        "rev": "de7c79179b5837dd9d57d3a80f9e01095b4082bf",
         "type": "gitlab"
       },
       "original": {
@@ -75,11 +75,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708702655,
-        "narHash": "sha256-qxT5jSLhelfLhQ07+AUxSTm1VnVH+hQxDkQSZ/m/Smo=",
+        "lastModified": 1709569716,
+        "narHash": "sha256-iOR44RU4jQ+YPGrn+uQeYAp7Xo7Z/+gT+wXJoGxxLTY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5101e457206dd437330d283d6626944e28794b3",
+        "rev": "617579a787259b9a6419492eaac670a5f7663917",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1706306805,
-        "narHash": "sha256-BWJdcDmpqZuxCStx4RUl5SD6uELy8hRa5YzwFTdWrts=",
+        "lastModified": 1708805268,
+        "narHash": "sha256-TyB6HacqcoIoK8tf5mwk/K9bkexCxjJsVXBp4+cbATI=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "24985136f4a5f98254e88c26d428114d206c2565",
+        "rev": "211c45ca8c36d7aebcff3e4b548142093fc85857",
         "type": "gitlab"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705659542,
-        "narHash": "sha256-WA3xVfAk1AYmFdwghT7mt/erYpsU6JPu9mdTEP/e9HQ=",
+        "lastModified": 1706981411,
+        "narHash": "sha256-cLbLPTL1CDmETVh4p0nQtvoF+FSEjsnJTFpTxhXywhQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "10cd9c53115061aa6a0a90aad0b0dde6a999cdb9",
+        "rev": "652fda4ca6dafeb090943422c34ae9145787af37",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706098335,
-        "narHash": "sha256-r3dWjT8P9/Ah5m5ul4WqIWD8muj5F+/gbCdjiNVBKmU=",
+        "lastModified": 1708702655,
+        "narHash": "sha256-qxT5jSLhelfLhQ07+AUxSTm1VnVH+hQxDkQSZ/m/Smo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a77ab169a83a4175169d78684ddd2e54486ac651",
+        "rev": "c5101e457206dd437330d283d6626944e28794b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,11 @@
 
   inputs = {
     # Nixpkgs
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
 
     # Home Manager
     home-manager = {
-      url = "github:nix-community/home-manager/release-23.05";
+      url = "github:nix-community/home-manager/release-23.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/home/configs/bash.nix
+++ b/home/configs/bash.nix
@@ -16,7 +16,7 @@
     historySize = -1;
     shellAliases = {
       diff = "diff --color=auto";
-      l = "exa --long --group --git --all";
+      l = "eza --long --group --git --all";
     };
     sessionVariables = {
       LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";

--- a/home/configs/firefox.nix
+++ b/home/configs/firefox.nix
@@ -8,9 +8,9 @@
       id = 0;
       name = "Default";
       extensions = [
-        inputs.firefox-addons.packages.${pkgs.system}.ublock-origin
         inputs.firefox-addons.packages.${pkgs.system}.darkreader
         inputs.firefox-addons.packages.${pkgs.system}.privacy-badger
+        inputs.firefox-addons.packages.${pkgs.system}.ublock-origin
       ];
       search = {
         default = "DuckDuckGo";

--- a/home/configs/gh.nix
+++ b/home/configs/gh.nix
@@ -1,7 +1,9 @@
 {
   programs.gh = {
     enable = true;
-    enableGitCredentialHelper = true;
+    gitCredentialHelper = {
+      enable = true;
+    };
     settings = {
       editor = "vim";
     };

--- a/home/configs/obs.nix
+++ b/home/configs/obs.nix
@@ -1,0 +1,10 @@
+{ config, pkgs, ... }:
+
+{
+  programs.obs-studio = {
+    enable = true;
+    plugins = with pkgs.obs-studio-plugins; [
+      obs-pipewire-audio-capture
+    ];
+  };
+}

--- a/home/configs/vscode.nix
+++ b/home/configs/vscode.nix
@@ -3,7 +3,7 @@
 {
   programs.vscode = {
     enable = true;
-    package = pkgs.vscodium;
+    package = pkgs.vscode;
     extensions = with pkgs.vscode-extensions; [
       # Search with:
       # https://search.nixos.org/packages?channel=22.05type=packages&query=vscode-extensions
@@ -18,6 +18,9 @@
       # Git
       eamodio.gitlens
       donjayamanne.githistory
+      # Github
+      github.copilot
+      github.copilot-chat
       github.vscode-pull-request-github
       # Editor appearance
       johnpapa.vscode-peacock
@@ -48,6 +51,8 @@
       "update.mode" = "none";
       # Trim newlines at end of file
       "files.trimFinalNewlines" = true;
+      # Display trimmed whitespace
+      "diffEditor.ignoreTrimWhitespace" = false;
     };
   };
 }

--- a/home/configs/zsh.nix
+++ b/home/configs/zsh.nix
@@ -6,7 +6,7 @@
     };
     shellAliases = {
       diff = "diff --color=auto";
-      l = "exa --long --group --git --all";
+      l = "eza --long --group --git --all";
     };
 
     oh-my-zsh = {

--- a/home/home.nix
+++ b/home/home.nix
@@ -124,7 +124,7 @@
     ./configs/rofi.nix
     ./configs/starship.nix
     ./configs/tmux.nix
-    ./configs/vscodium.nix
+    ./configs/vscode.nix
     # ./configs/zsh.nix
   ];
 

--- a/home/home.nix
+++ b/home/home.nix
@@ -62,6 +62,8 @@
     # Apps
     audacity # Audio editor
     avidemux # Video editor
+    brasero # CD/DVD burner
+    devede # CD/DVD creator
     filezilla # FTP client
     gimp # Image editor
     inkscape # SVG editor

--- a/home/home.nix
+++ b/home/home.nix
@@ -1,6 +1,17 @@
 { config, pkgs, ... }:
 
 {
+  nixpkgs = {
+    config = {
+      allowUnfree = true;
+      # Workaround: https://github.com/nix-community/home-manager/issues/2942
+      allowUnfreePredicate = (_: true);
+      permittedInsecurePackages = [
+        "electron-25.9.0" # 20240104 - Needed for Obsidian v1.4
+      ];
+    };
+  };
+
   # Let Home Manager install and manage itself
   programs.home-manager.enable = true;
 
@@ -17,28 +28,32 @@
   # Packages to be installed
   home.packages = with pkgs; [
     # Tools
+    appimage-run # Run AppImage files
     bat # `cat` clone
     bottom # Display process information (`top` alternative)
     ddrescue # dd, with extra functionality
     du-dust # Disk space usage (`du` alternative)
-    exa # File listing (`ls` alternative)
+    eza # File listing (`ls` alternative)
     fd # Find files/folders (`find` alternative)
     feh # Command line image viewer
     ffmpeg # Audio video manipulation
     gitleaks # Git repository secrets checker
     gparted # Disk partition tool
+    hdparm # Disk utility (set/get parameters, read-only speed test)
     htop # Display process information (`top` alternative)
     jq # Command line JSON parser
     neofetch # System information
     nmap # Network exploration
-    ripgrep # Fast grep
     p7zip # Compression tool
     powertop # Power consumption
+    ripgrep # Fast grep
     taskwarrior # Task manager
     tig # git text-mode interface
     tldr # Help pages
     tree # Display directory struture
+    unetbootin # Bootable USB creator
     unzip # Zip decompress
+    woeusb # Bootable USB creator for Windows media
     zip # Zip compress
 
     # Apps
@@ -48,13 +63,22 @@
     inkscape # SVG editor
     libreoffice # Office suite
     meld # Diff tools
+    telegram-desktop # Messaging
     subversion # Software version control
     vlc # Media player
+
+    obsidian # Notes
 
     # Browsers
     chromium
 
     # Fonts
+    (google-fonts.override {
+      fonts = [
+        "Teko"
+        "RedHatDisplay"
+      ];
+    })
     (nerdfonts.override {
       fonts = [
         "DejaVuSansMono"

--- a/home/home.nix
+++ b/home/home.nix
@@ -36,12 +36,13 @@
     eza # File listing (`ls` alternative)
     fd # Find files/folders (`find` alternative)
     feh # Command line image viewer
-    ffmpeg # Audio video manipulation
+    ffmpeg-full # Audio video manipulation
     gitleaks # Git repository secrets checker
     gparted # Disk partition tool
     hdparm # Disk utility (set/get parameters, read-only speed test)
     htop # Display process information (`top` alternative)
     jq # Command line JSON parser
+    mediainfo # Media file information
     neofetch # System information
     nmap # Network exploration
     p7zip # Compression tool
@@ -53,11 +54,14 @@
     tree # Display directory struture
     unetbootin # Bootable USB creator
     unzip # Zip decompress
+    usbutils # USB tools (lsusb)
+    v4l-utils # Video for Linux utilities
     woeusb # Bootable USB creator for Windows media
     zip # Zip compress
 
     # Apps
     audacity # Audio editor
+    avidemux # Video editor
     filezilla # FTP client
     gimp # Image editor
     inkscape # SVG editor
@@ -120,6 +124,7 @@
     ./configs/gh.nix
     ./configs/git.nix
     ./configs/neovim.nix
+    ./configs/obs.nix
     ./configs/polybar.nix
     ./configs/rofi.nix
     ./configs/starship.nix

--- a/hosts/x13/configuration.nix
+++ b/hosts/x13/configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 {
   imports = [

--- a/hosts/x13/configuration.nix
+++ b/hosts/x13/configuration.nix
@@ -107,9 +107,6 @@
   # Include zsh in /etc/shells
   # environment.shells = with pkgs; [ zsh ];
 
-  # Allow unfree packages
-  nixpkgs.config.allowUnfree = true;
-
   # System packages
   environment.systemPackages = with pkgs; [
     bash-completion

--- a/hosts/x13/configuration.nix
+++ b/hosts/x13/configuration.nix
@@ -61,7 +61,7 @@
   #  - mv $PWD/"DisplayLink USB Graphics Software for Ubuntu5.8-EXE.zip" $PWD/displaylink-580.zip
   #  - nix-prefetch-url file://$PWD/displaylink-580.zip
   #
-  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) ["displaylink"];
+  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "displaylink" ];
   services.xserver.videoDrivers = [ "displaylink" "modesetting" ];
 
   # Printing
@@ -110,19 +110,19 @@
       PLATFORM_PROFILE_ON_BAT = "low-power";
     };
   };
-    # Thermald (Intel only) - https://wiki.debian.org/thermald
-    # To be investigated if any benefit - Doesn't currently work due
-    # to lap detection, which can be ignored with `--ignore-cpuid-check`
-    # services.thermald = {
-    #   enable = true;
-    # };
+  # Thermald (Intel only) - https://wiki.debian.org/thermald
+  # To be investigated if any benefit - Doesn't currently work due
+  # to lap detection, which can be ignored with `--ignore-cpuid-check`
+  # services.thermald = {
+  #   enable = true;
+  # };
 
   users.users.timh = {
     isNormalUser = true;
     description = "timh";
     # "scanner" for scanners
     # "lp" for printer/scanners
-    extraGroups = [ "networkmanager" "wheel" "scanner" "lp"];
+    extraGroups = [ "networkmanager" "wheel" "scanner" "lp" ];
     packages = with pkgs; [ firefox git bottom ];
     shell = pkgs.bash;
   };

--- a/hosts/x13/configuration.nix
+++ b/hosts/x13/configuration.nix
@@ -52,6 +52,18 @@
   services.xserver.displayManager.lightdm.enable = true;
   services.xserver.desktopManager.cinnamon.enable = true;
 
+  # DisplayLink - https://nixos.wiki/wiki/Displaylink
+  # External Monitors
+  # Requires:
+  #  - (Feb 2024) `nix-prefetch-url --name displaylink-580.zip https://www.synaptics.com/sites/default/files/exe_files/2023-08/DisplayLink%20USB%20Graphics%20Software%20for%20Ubuntu5.8-EXE.zip`
+  #  OR
+  #  - Download latest to $PWD: https://www.synaptics.com/products/displaylink-graphics/downloads/ubuntu-5.8
+  #  - mv $PWD/"DisplayLink USB Graphics Software for Ubuntu5.8-EXE.zip" $PWD/displaylink-580.zip
+  #  - nix-prefetch-url file://$PWD/displaylink-580.zip
+  #
+  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) ["displaylink"];
+  services.xserver.videoDrivers = [ "displaylink" "modesetting" ];
+
   # Printing
   services.printing.enable = true;
   services.avahi.enable = true;

--- a/hosts/x13/configuration.nix
+++ b/hosts/x13/configuration.nix
@@ -71,6 +71,10 @@
   # For WiFi printers
   services.avahi.openFirewall = true;
 
+  # Scaanners
+  # SANE support
+  hardware.sane.enable = true;
+
   # Sound via Pipewire
   sound.enable = true;
   hardware.pulseaudio.enable = false;
@@ -106,17 +110,19 @@
       PLATFORM_PROFILE_ON_BAT = "low-power";
     };
   };
-#   # Thermald (Intel only) - https://wiki.debian.org/thermald
-#   # To be investigated if any benefit - Doesn't currently work do to
-#   # lap detection, which can be ignored with `--ignore-cpuid-check`
-#   services.thermald = {
-#     enable = true;
-#   };
+    # Thermald (Intel only) - https://wiki.debian.org/thermald
+    # To be investigated if any benefit - Doesn't currently work due
+    # to lap detection, which can be ignored with `--ignore-cpuid-check`
+    # services.thermald = {
+    #   enable = true;
+    # };
 
   users.users.timh = {
     isNormalUser = true;
     description = "timh";
-    extraGroups = [ "networkmanager" "wheel" ];
+    # "scanner" for scanners
+    # "lp" for printer/scanners
+    extraGroups = [ "networkmanager" "wheel" "scanner" "lp"];
     packages = with pkgs; [ firefox git bottom ];
     shell = pkgs.bash;
   };

--- a/hosts/x13/configuration.nix
+++ b/hosts/x13/configuration.nix
@@ -5,6 +5,8 @@
     ./hardware-configuration.nix
   ];
 
+  # Use `nixos-options` to see configuration options e.g. `nixos-options service.<service-name>`
+
   # Feature onfiguration
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
@@ -92,6 +94,12 @@
       PLATFORM_PROFILE_ON_BAT = "low-power";
     };
   };
+#   # Thermald (Intel only) - https://wiki.debian.org/thermald
+#   # To be investigated if any benefit - Doesn't currently work do to
+#   # lap detection, which can be ignored with `--ignore-cpuid-check`
+#   services.thermald = {
+#     enable = true;
+#   };
 
   users.users.timh = {
     isNormalUser = true;

--- a/hosts/x1c/configuration.nix
+++ b/hosts/x1c/configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 {
   imports = [

--- a/hosts/x1c/configuration.nix
+++ b/hosts/x1c/configuration.nix
@@ -5,6 +5,8 @@
     ./hardware-configuration.nix
   ];
 
+  # Use `nixos-options` to see configuration options e.g. `nixos-options service.<service-name>`
+
   # Feature onfiguration
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 

--- a/hosts/x1c/configuration.nix
+++ b/hosts/x1c/configuration.nix
@@ -56,6 +56,10 @@
   # For WiFi printers
   services.avahi.openFirewall = true;
 
+  # Scaanners
+  # SANE support
+  hardware.sane.enable = true;
+
   # Sound via Pipewire
   sound.enable = true;
   hardware.pulseaudio.enable = false;
@@ -95,7 +99,9 @@
   users.users.timh = {
     isNormalUser = true;
     description = "timh";
-    extraGroups = [ "networkmanager" "wheel" ];
+    # "scanner" for scanners
+    # "lp" for printer/scanners
+    extraGroups = [ "networkmanager" "wheel" "scanner" "lp"];
     packages = with pkgs; [ firefox git bottom ];
     shell = pkgs.bash;
   };

--- a/hosts/x1c/configuration.nix
+++ b/hosts/x1c/configuration.nix
@@ -92,9 +92,6 @@
   # Include zsh in /etc/shells
   # environment.shells = with pkgs; [ zsh ];
 
-  # Allow unfree packages
-  nixpkgs.config.allowUnfree = true;
-
   # System packages
   environment.systemPackages = with pkgs; [
     bash-completion

--- a/hosts/x1c/configuration.nix
+++ b/hosts/x1c/configuration.nix
@@ -46,7 +46,7 @@
   #  - mv $PWD/"DisplayLink USB Graphics Software for Ubuntu5.8-EXE.zip" $PWD/displaylink-580.zip
   #  - nix-prefetch-url file://$PWD/displaylink-580.zip
   #
-  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) ["displaylink"];
+  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "displaylink" ];
   services.xserver.videoDrivers = [ "displaylink" "modesetting" ];
 
   # Printing
@@ -101,7 +101,7 @@
     description = "timh";
     # "scanner" for scanners
     # "lp" for printer/scanners
-    extraGroups = [ "networkmanager" "wheel" "scanner" "lp"];
+    extraGroups = [ "networkmanager" "wheel" "scanner" "lp" ];
     packages = with pkgs; [ firefox git bottom ];
     shell = pkgs.bash;
   };

--- a/hosts/x1c/configuration.nix
+++ b/hosts/x1c/configuration.nix
@@ -15,7 +15,7 @@
   boot.loader.efi.canTouchEfiVariables = true;
   boot.loader.efi.efiSysMountPoint = "/boot/efi";
 
-    # Filesystem support
+  # Filesystem support
   boot.supportedFilesystems = [ "ntfs" ];
 
   # Networking
@@ -36,6 +36,18 @@
   # Desktop - Cinnamon
   services.xserver.displayManager.lightdm.enable = true;
   services.xserver.desktopManager.cinnamon.enable = true;
+
+  # DisplayLink - https://nixos.wiki/wiki/Displaylink
+  # External Monitors
+  # Requires:
+  #  - (Feb 2024) `nix-prefetch-url --name displaylink-580.zip https://www.synaptics.com/sites/default/files/exe_files/2023-08/DisplayLink%20USB%20Graphics%20Software%20for%20Ubuntu5.8-EXE.zip`
+  #  OR
+  #  - Download latest to $PWD: https://www.synaptics.com/products/displaylink-graphics/downloads/ubuntu-5.8
+  #  - mv $PWD/"DisplayLink USB Graphics Software for Ubuntu5.8-EXE.zip" $PWD/displaylink-580.zip
+  #  - nix-prefetch-url file://$PWD/displaylink-580.zip
+  #
+  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) ["displaylink"];
+  services.xserver.videoDrivers = [ "displaylink" "modesetting" ];
 
   # Printing
   services.printing.enable = true;


### PR DESCRIPTION
# What's changed

- Move to 23.11
- Add unfree config for home-manager
- Add various AV tools
- Add OBS
- Add USB tools
- Switch to VSCode
- Add GH Co-Pilot to VSCode
- Add new fonts
- Add displaylink support
- Add printer scanner support
