### PR TITLE
Update HA to 2025.3.4

### DIFF
--- a/hosts/opx7070/configuration.nix
+++ b/hosts/opx7070/configuration.nix
@@ -49,6 +49,9 @@
   # Required for ZFS
   networking.hostId = "6b3f7344"; # `head -c4 /dev/urandom | od -A none -t x4`
   services.tailscale.enable = true;
+  # Workaround - Tailscale causing NetworkManager-wait-online to fail on start
+  # https://github.com/NixOS/nixpkgs/issues/180175
+  systemd.services.NetworkManager-wait-online.enable = lib.mkForce false;
 
   # Localisation
   time.timeZone = "Europe/Dublin";

--- a/hosts/opx7070/configuration.nix
+++ b/hosts/opx7070/configuration.nix
@@ -139,7 +139,7 @@
           "--network=host"
         ];
         # https://github.com/home-assistant/core/releases
-        image = "ghcr.io/home-assistant/home-assistant:2025.3.3";
+        image = "ghcr.io/home-assistant/home-assistant:2025.3.4";
         # https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/zi/zigbee2mqtt/package.nix
         z2mPackage = pkgs.unstable.zigbee2mqtt_1;
       };

--- a/hosts/x13/configuration.nix
+++ b/hosts/x13/configuration.nix
@@ -39,6 +39,9 @@
   networking.hostName = "x13";
   networking.networkmanager.enable = true;
   services.tailscale.enable = true;
+  # Workaround - Tailscale causing NetworkManager-wait-online to fail on start
+  # https://github.com/NixOS/nixpkgs/issues/180175
+  systemd.services.NetworkManager-wait-online.enable = lib.mkForce false;
 
   # Localisation
   time.timeZone = "Europe/Dublin";

--- a/hosts/x1c/configuration.nix
+++ b/hosts/x1c/configuration.nix
@@ -37,6 +37,9 @@
   networking.hostName = "x1c";
   networking.networkmanager.enable = true;
   services.tailscale.enable = true;
+  # Workaround - Tailscale causing NetworkManager-wait-online to fail on start
+  # https://github.com/NixOS/nixpkgs/issues/180175
+  systemd.services.NetworkManager-wait-online.enable = lib.mkForce false;
 
   # Localisation
   time.timeZone = "Europe/Dublin";


### PR DESCRIPTION
# What's changed

- Update HA to 2025.3.4
- Add workaround - Tailscale causing NetworkManager-wait-online to fail on start
  - https://github.com/NixOS/nixpkgs/issues/180175

