### PR TITLE
Update HA and systemd for network services

### DIFF
--- a/hosts/m625q/configuration.nix
+++ b/hosts/m625q/configuration.nix
@@ -82,7 +82,10 @@
       # Recursive DNS resolver
       unbound.enable = true;
       # Podman virtualisation
-      podman.enable = true;
+      podman = {
+        enable = true;
+        autoPrune = true;
+      };
       # SSH server
       ssh.enable = true;
     };

--- a/hosts/opx7070/configuration.nix
+++ b/hosts/opx7070/configuration.nix
@@ -96,7 +96,10 @@
       # Glances monitoring service
       glances.enable = true;
       # Podman virtualisation
-      podman.enable = true;
+      podman = {
+        enable = true;
+        autoPrune = true;
+      };
       # Slimserver / LMS / Lyrion
       slimserver = {
         enable = true;

--- a/hosts/opx7070/configuration.nix
+++ b/hosts/opx7070/configuration.nix
@@ -46,7 +46,12 @@
   networking.networkmanager.enable = true;
   # Required for ZFS
   networking.hostId = "6b3f7344"; # `head -c4 /dev/urandom | od -A none -t x4`
-  services.tailscale.enable = true;
+  services.tailscale = {
+    enable = true;
+    extraUpFlags = [
+      "--accept-dns=false"
+    ];
+  };
   # Workaround - Tailscale causing NetworkManager-wait-online to fail on start
   # https://github.com/NixOS/nixpkgs/issues/180175
   systemd.services.NetworkManager-wait-online.enable = lib.mkForce false;

--- a/hosts/opx7070/configuration.nix
+++ b/hosts/opx7070/configuration.nix
@@ -109,6 +109,7 @@
         enable = true;
         extraOptions = [
           "--network=host"
+          "--dns=9.9.9.9" # WORKAROUND - HA can start before DNS is up on boot
         ];
         # https://github.com/home-assistant/core/releases
         image = "ghcr.io/home-assistant/home-assistant:2025.4.4";

--- a/hosts/opx7070/configuration.nix
+++ b/hosts/opx7070/configuration.nix
@@ -111,7 +111,7 @@
           "--network=host"
         ];
         # https://github.com/home-assistant/core/releases
-        image = "ghcr.io/home-assistant/home-assistant:2025.4.3";
+        image = "ghcr.io/home-assistant/home-assistant:2025.4.4";
         # https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/zi/zigbee2mqtt/package.nix
         z2mPackage = pkgs.unstable.zigbee2mqtt_1;
       };

--- a/modules/services/hass/default.nix
+++ b/modules/services/hass/default.nix
@@ -84,6 +84,12 @@ in
           };
         }];
     };
+    # Service can return `Error: Cannot assign requested address` on boot
+    # so restart "always"
+    systemd.services.mosquitto.serviceConfig = {
+      Restart = lib.mkForce "always";
+      RestartSec = "10";
+    };
 
     # zigbee2mqtt service
     services.zigbee2mqtt = {
@@ -143,11 +149,16 @@ in
         };
       };
     };
-    # z2m stops (with exit 0) when the adapter disconnects or isn't
-    # available yet, so restart "always"
-    systemd.services.zigbee2mqtt.serviceConfig = {
-      Restart = lib.mkForce "always";
-      RestartSec = "10";
+    systemd.services.zigbee2mqtt = {
+      serviceConfig = {
+        # z2m stops (with exit 0) when the adapter disconnects or isn't
+        # available yet, so restart "always"
+        Restart = lib.mkForce "always";
+        RestartSec = "10";
+      };
+      # Ensure network is up before starting
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
     };
 
     # Home Assistant container
@@ -161,14 +172,18 @@ in
         extraOptions = cfg.extraOptions;
       };
     };
-    # Results in the creation of /var/lib/hass
-    # User and Group could be specified here but it would break the container,
-    # as the container is running as root - See https://github.com/NixOS/nixpkgs/issues/207050
-    # For now, the files will be owned as root
-    systemd.services."${config.virtualisation.oci-containers.backend}-hass".serviceConfig = {
-      StateDirectory = "hass";
+    systemd.services."${config.virtualisation.oci-containers.backend}-hass" = {
+      # Results in the creation of /var/lib/hass
+      # User and Group could be specified here but it would break the container,
+      # as the container is running as root - See https://github.com/NixOS/nixpkgs/issues/207050
+      # For now, the files will be owned as root
+      serviceConfig = {
+        StateDirectory = "hass";
+      };
+      # Ensure DNS is available before starting
+      wants = [ "nss-lookup.target" ];
+      after = [ "nss-lookup.target" ];
     };
-
     networking.firewall.allowedTCPPorts = [ hassPort mosquittoPort z2mPort ];
   };
 }

--- a/modules/services/podman/default.nix
+++ b/modules/services/podman/default.nix
@@ -15,6 +15,11 @@ in
         type = lib.types.bool;
         default = false;
       };
+      autoPrune = lib.mkOption {
+        description = "Enable auto prune";
+        type = lib.types.bool;
+        default = false;
+      };
     };
   };
 
@@ -23,6 +28,9 @@ in
       podman = {
         enable = true;
         dockerCompat = if cfg.dockerCompat then true else false;
+        autoPrune.enable = if cfg.autoPrune then true else false;
+        autoPrune.dates = if cfg.autoPrune then [ "weekly" ] else [ ];
+        autoPrune.flags = if cfg.autoPrune then [ "--all" ] else [ ];
       };
     };
   };

--- a/modules/services/podman/default.nix
+++ b/modules/services/podman/default.nix
@@ -29,7 +29,7 @@ in
         enable = true;
         dockerCompat = if cfg.dockerCompat then true else false;
         autoPrune.enable = if cfg.autoPrune then true else false;
-        autoPrune.dates = if cfg.autoPrune then [ "weekly" ] else [ ];
+        autoPrune.dates = if cfg.autoPrune then "weekly" else "";
         autoPrune.flags = if cfg.autoPrune then [ "--all" ] else [ ];
       };
     };

--- a/modules/services/slimserver/default.nix
+++ b/modules/services/slimserver/default.nix
@@ -33,6 +33,11 @@ in
       package = cfg.package;
       dataDir = cfg.dataDir;
     };
+    systemd.services.slimserver = {
+      # Ensure network is up before starting
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+    };
 
     networking.firewall.allowedTCPPorts = [ slimServerPort slimServerCliPort playerPort ];
     networking.firewall.allowedUDPPorts = [ slimServerPort slimServerCliPort playerPort ];


### PR DESCRIPTION
# What's changed

- Disable Tailscale DNS
- Update HA to 2025.4.4
- Add HA DNS workaround
- Add autopruning for containers
- Update systemd dependencies for network sensitive services

