### PR TITLE
Add start and end marked to auto upgrade log

### DIFF
--- a/modules/services/tailscale/default.nix
+++ b/modules/services/tailscale/default.nix
@@ -23,8 +23,8 @@ in
   config = lib.mkIf cfg.enable {
     services.tailscale = {
       enable = true;
-      # DNS is enabled by default
-      extraUpFlags = if cfg.enableDNS then [ ] else [ "--accept-dns=false" ];
+      # DNS is enabled by default, so disable it if preferred
+      extraSetFlags = if cfg.enableDNS then [ ] else [ "--accept-dns=false" ];
     };
 
     # WORKAROUND - Tailscale causing NetworkManager-wait-online to fail on start


### PR DESCRIPTION
# What's changed

- Add timestamp markers to Auto Upgrade
- Use different setting to turn off TS DNS
